### PR TITLE
Make RollbackLast actually work

### DIFF
--- a/gormigrate_test.go
+++ b/gormigrate_test.go
@@ -74,6 +74,12 @@ func TestMigration(t *testing.T) {
 	assert.True(t, db.HasTable(&Person{}))
 	assert.False(t, db.HasTable(&Pet{}))
 	assert.Equal(t, 1, tableCount(db, "migrations"))
+
+	err = m.RollbackLast()
+	assert.Nil(t, err)
+	assert.False(t, db.HasTable(&Person{}))
+	assert.False(t, db.HasTable(&Pet{}))
+	assert.Equal(t, 0, tableCount(db, "migrations"))
 }
 
 func TestInitSchema(t *testing.T) {


### PR DESCRIPTION
Problem is that if you have multiple migrations registered, and you'll try to run `RollbackLast` method, it will always try to roll back last migration in this list and not in those that were registered in `migrations` table. 

So if you already rolled back last migration and try to run again to roll back the next one, you will always get an error that there is no such table.

This pull has breaking change since I've changed `migrations` table structure to fetch the last migration.