### PR TITLE
Add methods MigrateTo and RollbackTo

### DIFF
--- a/gormigrate.go
+++ b/gormigrate.go
@@ -109,6 +109,15 @@ func (g *Gormigrate) InitSchema(initSchema InitSchemaFunc) {
 
 // Migrate executes all migrations that did not run yet.
 func (g *Gormigrate) Migrate() error {
+	return g.migrate("")
+}
+
+// Migrate executes all migrations that did not run yet up to the migration that matches `migrationId`.
+func (g *Gormigrate) MigrateTo(migrationId string) error {
+	return g.migrate(migrationId)
+}
+
+func (g *Gormigrate) migrate(migrationId string) error {
 	if err := g.checkDuplicatedID(); err != nil {
 		return err
 	}
@@ -131,6 +140,9 @@ func (g *Gormigrate) Migrate() error {
 		if err := g.runMigration(migration); err != nil {
 			g.rollback()
 			return err
+		}
+		if migrationId != "" && migration.ID == migrationId {
+			break
 		}
 	}
 
@@ -165,6 +177,31 @@ func (g *Gormigrate) RollbackLast() error {
 	return nil
 }
 
+// RollbackTo undoes migrations up to the given migration that matches the `migrationId`.
+// Migration with the matching `migrationId` is not rolled back.
+func (g *Gormigrate) RollbackTo(migrationId string) error {
+	if len(g.migrations) == 0 {
+		return ErrNoMigrationDefined
+	}
+
+	g.begin()
+
+	for i := len(g.migrations) - 1; i >= 0; i-- {
+		migration := g.migrations[i]
+		if migration.ID == migrationId {
+			break
+		}
+		if g.migrationDidRun(migration) {
+			if err := g.rollbackMigration(migration, false); err != nil {
+				g.rollback()
+				return err
+			}
+		}
+	}
+
+	return g.commit()
+}
+
 func (g *Gormigrate) getLastRunnedMigration() (*Migration, error) {
 	for i := len(g.migrations) - 1; i >= 0; i-- {
 		migration := g.migrations[i]
@@ -177,11 +214,20 @@ func (g *Gormigrate) getLastRunnedMigration() (*Migration, error) {
 
 // RollbackMigration undo a migration.
 func (g *Gormigrate) RollbackMigration(m *Migration) error {
+	return g.rollbackMigration(m, true)
+}
+
+// rollbackMigration rolls back the given transaction. If `withTransaction` is true, then the operation is wrapped in
+// transaction (if g.options.UseTransaction is also true).
+// Call rollbackMigration with `withTransaction` false if you want to wrap multiple operations in a single transaction.
+func (g *Gormigrate) rollbackMigration(m *Migration, withTransaction bool) error {
 	if m.Rollback == nil {
 		return ErrRollbackImpossible
 	}
 
-	g.begin()
+	if withTransaction {
+		g.begin()
+	}
 
 	if err := m.Rollback(g.tx); err != nil {
 		return err
@@ -189,11 +235,16 @@ func (g *Gormigrate) RollbackMigration(m *Migration) error {
 
 	sql := fmt.Sprintf("DELETE FROM %s WHERE %s = ?", g.options.TableName, g.options.IDColumnName)
 	if err := g.db.Exec(sql, m.ID).Error; err != nil {
-		g.rollback()
+		if withTransaction {
+			g.rollback()
+		}
 		return err
 	}
 
-	return g.commit()
+	if withTransaction {
+		return g.commit()
+	}
+	return nil
 }
 
 func (g *Gormigrate) runInitSchema() error {


### PR DESCRIPTION
Add methods MigrateTo and RollbackTo.

MigrateTo: run migrations up to the given migration ID.
RollbackTo: rollback migrations up to the given migration ID. Important to have this method in case of a release rollback when only certain migrations need to be rolled back.