### PR TITLE
Feature id type uint64

### DIFF
--- a/gormigrate.go
+++ b/gormigrate.go
@@ -3,6 +3,7 @@ package gormigrate
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/jinzhu/gorm"
 )
@@ -25,6 +26,9 @@ type Options struct {
 	// UseTransaction makes Gormigrate execute migrations inside a single transaction.
 	// Keep in mind that not all databases support DDL commands inside transactions.
 	UseTransaction bool
+	// SortMigration is the flag is responsible for the sorting of migrations on the ID,
+	// the migrations is sorted before running
+	SortMigration bool
 }
 
 // Migration represents a database migration (a modification to be made on the database).
@@ -61,6 +65,7 @@ var (
 		TableName:      "migrations",
 		IDColumnName:   "id",
 		UseTransaction: false,
+		SortMigration:  false,
 	}
 
 	// ErrRollbackImpossible is returned when trying to rollback a migration
@@ -86,6 +91,12 @@ func New(db *gorm.DB, options *Options, migrations []*Migration) *Gormigrate {
 	if options.IDColumnName == "" {
 		options.IDColumnName = DefaultOptions.IDColumnName
 	}
+	if options.SortMigration {
+		sort.Slice(migrations, func(i, j int) bool {
+			return migrations[i].ID < migrations[j].ID
+		})
+	}
+
 	return &Gormigrate{
 		db:         db,
 		options:    options,

--- a/gormigrate_test.go
+++ b/gormigrate_test.go
@@ -18,7 +18,7 @@ type database struct {
 
 var migrations = []*Migration{
 	{
-		ID: "201608301400",
+		ID: 201608301400,
 		Migrate: func(tx *gorm.DB) error {
 			return tx.AutoMigrate(&Person{}).Error
 		},
@@ -27,7 +27,7 @@ var migrations = []*Migration{
 		},
 	},
 	{
-		ID: "201608301430",
+		ID: 201608301430,
 		Migrate: func(tx *gorm.DB) error {
 			return tx.AutoMigrate(&Pet{}).Error
 		},
@@ -38,7 +38,7 @@ var migrations = []*Migration{
 }
 
 var extendedMigrations = append(migrations, &Migration{
-	ID: "201807221927",
+	ID: 201807221927,
 	Migrate: func(tx *gorm.DB) error {
 		return tx.AutoMigrate(&Book{}).Error
 	},
@@ -92,7 +92,7 @@ func TestMigrateTo(t *testing.T) {
 	forEachDatabase(t, func(db *gorm.DB) {
 		m := New(db, DefaultOptions, extendedMigrations)
 
-		err := m.MigrateTo("201608301430")
+		err := m.MigrateTo(201608301430)
 		assert.NoError(t, err)
 		assert.True(t, db.HasTable(&Person{}))
 		assert.True(t, db.HasTable(&Pet{}))
@@ -114,7 +114,7 @@ func TestRollbackTo(t *testing.T) {
 		assert.Equal(t, 3, tableCount(t, db, "migrations"))
 
 		// Rollback to the first migration: only the last 2 migrations are expected to be rolled back.
-		err = m.RollbackTo("201608301400")
+		err = m.RollbackTo(201608301400)
 		assert.NoError(t, err)
 		assert.True(t, db.HasTable(&Person{}))
 		assert.False(t, db.HasTable(&Pet{}))
@@ -162,13 +162,13 @@ func TestDuplicatedID(t *testing.T) {
 	forEachDatabase(t, func(db *gorm.DB) {
 		migrationsDuplicatedID := []*Migration{
 			{
-				ID: "201705061500",
+				ID: 201705061500,
 				Migrate: func(tx *gorm.DB) error {
 					return nil
 				},
 			},
 			{
-				ID: "201705061500",
+				ID: 201705061500,
 				Migrate: func(tx *gorm.DB) error {
 					return nil
 				},


### PR DESCRIPTION
Change the ID type of the migration to uint64

Using a string ID does not make much sense, because comments
to the name of the migration are unnecessary, they can always
be found in the code by ID. By using a numeric migration ID,
you can sort the migration without worrying about how they
are located in the slice.

_If need to have a migration comment in the database, i can separately make the `comment` field_

P. S. I propose to call this update as gormigrate v2.0.0