### PR TITLE
Validating the migration ID exist in the list of migrations

### DIFF
--- a/gormigrate.go
+++ b/gormigrate.go
@@ -113,7 +113,10 @@ func (g *Gormigrate) InitSchema(initSchema InitSchemaFunc) {
 
 // Migrate executes all migrations that did not run yet.
 func (g *Gormigrate) Migrate() error {
-	return g.migrate("")
+	if len(g.migrations) == 0 {
+		return ErrNoMigrationDefined
+	}
+	return g.migrate(g.migrations[len(g.migrations)-1].ID)
 }
 
 // MigrateTo executes all migrations that did not run yet up to the migration that matches `migrationID`.
@@ -173,9 +176,6 @@ func (g *Gormigrate) checkDuplicatedID() error {
 }
 
 func (g *Gormigrate) checkIDExist(migrationID string) error {
-	if migrationID == "" {
-		return nil
-	}
 	for _, migrate := range g.migrations {
 		if migrate.ID == migrationID {
 			return nil

--- a/gormigrate_test.go
+++ b/gormigrate_test.go
@@ -143,6 +143,16 @@ func TestInitSchema(t *testing.T) {
 	})
 }
 
+func TestMigrationIDDoesNotExist(t *testing.T) {
+	forEachDatabase(t, func(db *gorm.DB) {
+		m := New(db, DefaultOptions, migrations)
+		assert.Equal(t, ErrMigrationIDDoesNotExist, m.MigrateTo("1234"))
+		assert.Equal(t, ErrMigrationIDDoesNotExist, m.RollbackTo("1234"))
+		assert.Equal(t, ErrMigrationIDDoesNotExist, m.MigrateTo(""))
+		assert.Equal(t, ErrMigrationIDDoesNotExist, m.RollbackTo(""))
+	})
+}
+
 func TestMissingID(t *testing.T) {
 	forEachDatabase(t, func(db *gorm.DB) {
 		migrationsMissingID := []*Migration{


### PR DESCRIPTION
Return an error if the migration id passed that `MigrateTo` and `RollbackTo` does not exist in the list of migrations.

#20 