### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ m.InitSchema(func(tx *gorm.DB) error {
 		&Person{},
 		&Pet{},
 		// all other tables of you app
-	)
+	).Error
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Need `.Error` after `tx.AutoMigrate()` to get error in sample code.