### PR TITLE
Fail migration with error if DB contains unknown migrations.

### DIFF
--- a/gormigrate_test.go
+++ b/gormigrate_test.go
@@ -366,6 +366,20 @@ func TestMigration_WithUseTransactionsShouldRollback(t *testing.T) {
 	}, "postgres", "sqlite3", "mssql")
 }
 
+func TestUnexpectedMigration(t *testing.T) {
+	forEachDatabase(t, func(db *gorm.DB) {
+		m := New(db, DefaultOptions, migrations)
+
+		// Migrate without initialisation
+		assert.NoError(t, m.Migrate())
+
+		// Try with fewer migrations. Should fail as we see a migration in the db that
+		// we don't recognise any more
+		n := New(db, DefaultOptions, migrations[:1])
+		assert.Error(t, n.Migrate())
+	})
+}
+
 func tableCount(t *testing.T, db *gorm.DB, tableName string) (count int) {
 	assert.NoError(t, db.Table(tableName).Count(&count).Error)
 	return

--- a/gormigrate_test.go
+++ b/gormigrate_test.go
@@ -369,7 +369,7 @@ func TestMigration_WithUseTransactionsShouldRollback(t *testing.T) {
 func TestUnexpectedMigrationEnabled(t *testing.T) {
 	forEachDatabase(t, func(db *gorm.DB) {
 		options := DefaultOptions
-		options.ValidateDBMigrationIDs = true
+		options.ValidateUnknownMigrations = true
 		m := New(db, options, migrations)
 
 		// Migrate without initialisation
@@ -378,14 +378,14 @@ func TestUnexpectedMigrationEnabled(t *testing.T) {
 		// Try with fewer migrations. Should fail as we see a migration in the db that
 		// we don't recognise any more
 		n := New(db, DefaultOptions, migrations[:1])
-		assert.Error(t, n.Migrate())
+		assert.Equal(t, ErrUnknownPastMigration, n.Migrate())
 	})
 }
 
 func TestUnexpectedMigrationDisabled(t *testing.T) {
 	forEachDatabase(t, func(db *gorm.DB) {
 		options := DefaultOptions
-		options.ValidateDBMigrationIDs = false
+		options.ValidateUnknownMigrations = false
 		m := New(db, options, migrations)
 
 		// Migrate without initialisation

--- a/gormigrate_test.go
+++ b/gormigrate_test.go
@@ -366,9 +366,11 @@ func TestMigration_WithUseTransactionsShouldRollback(t *testing.T) {
 	}, "postgres", "sqlite3", "mssql")
 }
 
-func TestUnexpectedMigration(t *testing.T) {
+func TestUnexpectedMigrationEnabled(t *testing.T) {
 	forEachDatabase(t, func(db *gorm.DB) {
-		m := New(db, DefaultOptions, migrations)
+		options := DefaultOptions
+		options.ValidateDBMigrationIDs = true
+		m := New(db, options, migrations)
 
 		// Migrate without initialisation
 		assert.NoError(t, m.Migrate())
@@ -377,6 +379,22 @@ func TestUnexpectedMigration(t *testing.T) {
 		// we don't recognise any more
 		n := New(db, DefaultOptions, migrations[:1])
 		assert.Error(t, n.Migrate())
+	})
+}
+
+func TestUnexpectedMigrationDisabled(t *testing.T) {
+	forEachDatabase(t, func(db *gorm.DB) {
+		options := DefaultOptions
+		options.ValidateDBMigrationIDs = false
+		m := New(db, options, migrations)
+
+		// Migrate without initialisation
+		assert.NoError(t, m.Migrate())
+
+		// Try with fewer migrations. Should pass as we see a migration in the db that
+		// we don't recognise any more, but the validation defaults off
+		n := New(db, DefaultOptions, migrations[:1])
+		assert.NoError(t, n.Migrate())
 	})
 }
 


### PR DESCRIPTION
If gormigrate finds migrations in the DB table that aren't in the code provided list then it is likely the software is pointed at the wrong DB or somehow older code is running. Either way, we should not continue to work with this DB without human intervention.

I actually hit this in a production situation, and it was confusing as to why things were failing down the line (as the DB didn't match the model). I'd like to make it an explicit failure rather than something caught later.

Very happy to fix/improve things