### PR TITLE
CreateTable on Rollback

### DIFF
--- a/gormigrate.go
+++ b/gormigrate.go
@@ -250,6 +250,10 @@ func (g *Gormigrate) RollbackLast() error {
 
 	g.begin()
 	defer g.rollback()
+	
+	if err := g.createMigrationTableIfNotExists(); err != nil {
+		return err
+	}
 
 	lastRunMigration, err := g.getLastRunMigration()
 	if err != nil {
@@ -275,6 +279,10 @@ func (g *Gormigrate) RollbackTo(migrationID string) error {
 
 	g.begin()
 	defer g.rollback()
+	
+	if err := g.createMigrationTableIfNotExists(); err != nil {
+		return err
+	}
 
 	for i := len(g.migrations) - 1; i >= 0; i-- {
 		migration := g.migrations[i]
@@ -314,6 +322,10 @@ func (g *Gormigrate) getLastRunMigration() (*Migration, error) {
 func (g *Gormigrate) RollbackMigration(m *Migration) error {
 	g.begin()
 	defer g.rollback()
+	
+	if err := g.createMigrationTableIfNotExists(); err != nil {
+		return err
+	}
 
 	if err := g.rollbackMigration(m); err != nil {
 		return err


### PR DESCRIPTION
This Library should not crash on rollback
(maybe define an extra Error would be an alternative)