### PR TITLE
Add support to get last run migration and also automatic rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,24 @@ import (
 
 	"github.com/go-gormigrate/gormigrate/v2"
 	"gorm.io/gorm"
-	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	"gorm.io/driver/sqlite"
 )
 
 func main() {
-	db, err := gorm.Open("sqlite3", "mydb.sqlite3")
+  newLogger := logger.New(
+    log.New(os.Stdout, "\r\n", log.LstdFlags), // io writer
+    logger.Config{
+      SlowThreshold:              time.Second,   // Slow SQL threshold
+      LogLevel:                   logger.Silent, // Log level
+      IgnoreRecordNotFoundError: true,           // Ignore ErrRecordNotFound error for logger
+      Colorful:                  false,          // Disable color
+    },
+  )
+
+	db, err := db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{ Logger: newLogger })
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	db.LogMode(true)
 
 	m := gormigrate.New(db, gormigrate.DefaultOptions, []*gormigrate.Migration{
 		// create persons table

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ type Options struct {
 	// ValidateUnknownMigrations will cause migrate to fail if there's unknown migration
 	// IDs in the database
 	ValidateUnknownMigrations bool
+	// AutomaticRollback will automatically run rollback methods if provided
+	// and if migrate function failed. This is only done when UseTransaction is disabled.
+	// Otherwise it will be rollback by the transaction itself.
+	AutomaticRollback bool
 }
 ```
 

--- a/gormigrate.go
+++ b/gormigrate.go
@@ -294,6 +294,20 @@ func (g *Gormigrate) RollbackTo(migrationID string) error {
 	return g.commit()
 }
 
+func (g *Gormigrate) GetLastRunMigrationID() (string, error) {
+	mig, err := g.GetLastRunMigration()
+	// Check error
+	if err != nil {
+		return "", err
+	}
+
+	return mig.ID, nil
+}
+
+func (g *Gormigrate) GetLastRunMigration() (*Migration, error) {
+	return g.getLastRunMigration()
+}
+
 func (g *Gormigrate) getLastRunMigration() (*Migration, error) {
 	for i := len(g.migrations) - 1; i >= 0; i-- {
 		migration := g.migrations[i]

--- a/gormigrate_test.go
+++ b/gormigrate_test.go
@@ -586,7 +586,7 @@ func forEachDatabase(t *testing.T, fn func(database *gorm.DB), dialects ...strin
 			require.NoError(t, err, "Could not connect to database %s, %v", database.dialect, err)
 
 			// ensure tables do not exists
-			assert.NoError(t, db.Migrator().DropTable("migrations", "people", "pets"))
+			assert.NoError(t, db.Migrator().DropTable("migrations", "people", "pets", "cars"))
 
 			fn(db)
 		}()

--- a/gormigrate_test.go
+++ b/gormigrate_test.go
@@ -365,6 +365,174 @@ func TestMigration_WithUseTransactionsShouldRollback(t *testing.T) {
 	}, "postgres", "sqlite3", "mssql")
 }
 
+// This test will only focus on automatic rollback or not, not on the database itself or migrations.
+func TestMigration_WithAutomaticRollbackShouldRollback(t *testing.T) {
+	t.Run("rollback without any error", func(t *testing.T) {
+		wantedError := errors.New("wanted")
+		rollbackCalled := false
+
+		forEachDatabase(t, func(db *gorm.DB) {
+			m := New(db, &Options{AutomaticRollback: true}, []*Migration{
+				{
+					ID: "201904231300",
+					Migrate: func(tx *gorm.DB) error {
+						return wantedError
+					},
+					Rollback: func(tx *gorm.DB) error {
+						rollbackCalled = true
+						return nil
+					},
+				},
+			})
+
+			// Migration should return an error and not leave around a Pet table
+			err := m.Migrate()
+			assert.Error(t, err)
+			assert.Equal(t, wantedError, err)
+			assert.True(t, rollbackCalled)
+		})
+	})
+
+	t.Run("rollback with an error", func(t *testing.T) {
+		wantedError := errors.New("wanted")
+		rollbackError := errors.New("rollback error")
+		rollbackCalled := false
+
+		forEachDatabase(t, func(db *gorm.DB) {
+			m := New(db, &Options{AutomaticRollback: true}, []*Migration{
+				{
+					ID: "201904231300",
+					Migrate: func(tx *gorm.DB) error {
+						return wantedError
+					},
+					Rollback: func(tx *gorm.DB) error {
+						rollbackCalled = true
+						return rollbackError
+					},
+				},
+			})
+
+			// Migration should return an error and not leave around a Pet table
+			err := m.Migrate()
+			assert.Error(t, err)
+			assert.Equal(t, wantedError, err)
+			assert.True(t, rollbackCalled)
+		})
+	})
+}
+
+// This test will only focus on automatic rollback or not, not on the database itself or migrations.
+func TestMigration_WithoutAutomaticRollbackShouldNotRollback(t *testing.T) {
+	t.Run("rollback without any error", func(t *testing.T) {
+		wantedError := errors.New("wanted")
+		rollbackCalled := false
+
+		forEachDatabase(t, func(db *gorm.DB) {
+			m := New(db, DefaultOptions, []*Migration{
+				{
+					ID: "201904231300",
+					Migrate: func(tx *gorm.DB) error {
+						return wantedError
+					},
+					Rollback: func(tx *gorm.DB) error {
+						rollbackCalled = true
+						return nil
+					},
+				},
+			})
+
+			// Migration should return an error and not leave around a Pet table
+			err := m.Migrate()
+			assert.Error(t, err)
+			assert.Equal(t, wantedError, err)
+			assert.False(t, rollbackCalled)
+		})
+	})
+
+	t.Run("rollback with an error", func(t *testing.T) {
+		wantedError := errors.New("wanted")
+		rollbackError := errors.New("rollback error")
+		rollbackCalled := false
+
+		forEachDatabase(t, func(db *gorm.DB) {
+			m := New(db, DefaultOptions, []*Migration{
+				{
+					ID: "201904231300",
+					Migrate: func(tx *gorm.DB) error {
+						return wantedError
+					},
+					Rollback: func(tx *gorm.DB) error {
+						rollbackCalled = true
+						return rollbackError
+					},
+				},
+			})
+
+			// Migration should return an error and not leave around a Pet table
+			err := m.Migrate()
+			assert.Error(t, err)
+			assert.Equal(t, wantedError, err)
+			assert.False(t, rollbackCalled)
+		})
+	})
+}
+
+// This test will only focus on automatic rollback or not, not on the database itself or migrations.
+func TestMigration_WithoutAutomaticRollbackAndUseTransactionShouldNotRollback(t *testing.T) {
+	t.Run("rollback without any error", func(t *testing.T) {
+		wantedError := errors.New("wanted")
+		rollbackCalled := false
+
+		forEachDatabase(t, func(db *gorm.DB) {
+			m := New(db, &Options{UseTransaction: true, AutomaticRollback: true}, []*Migration{
+				{
+					ID: "201904231300",
+					Migrate: func(tx *gorm.DB) error {
+						return wantedError
+					},
+					Rollback: func(tx *gorm.DB) error {
+						rollbackCalled = true
+						return nil
+					},
+				},
+			})
+
+			// Migration should return an error and not leave around a Pet table
+			err := m.Migrate()
+			assert.Error(t, err)
+			assert.Equal(t, wantedError, err)
+			assert.False(t, rollbackCalled)
+		})
+	})
+
+	t.Run("rollback with an error", func(t *testing.T) {
+		wantedError := errors.New("wanted")
+		rollbackError := errors.New("rollback error")
+		rollbackCalled := false
+
+		forEachDatabase(t, func(db *gorm.DB) {
+			m := New(db, &Options{UseTransaction: true, AutomaticRollback: true}, []*Migration{
+				{
+					ID: "201904231300",
+					Migrate: func(tx *gorm.DB) error {
+						return wantedError
+					},
+					Rollback: func(tx *gorm.DB) error {
+						rollbackCalled = true
+						return rollbackError
+					},
+				},
+			})
+
+			// Migration should return an error and not leave around a Pet table
+			err := m.Migrate()
+			assert.Error(t, err)
+			assert.Equal(t, wantedError, err)
+			assert.False(t, rollbackCalled)
+		})
+	})
+}
+
 func TestUnexpectedMigrationEnabled(t *testing.T) {
 	forEachDatabase(t, func(db *gorm.DB) {
 		options := DefaultOptions


### PR DESCRIPTION
That will resolve issue #76  .

Other commit will fix the example usage and also some test stability.