### PR TITLE
Refactor plain sql mutation statements (create, insert, delete) into native gorm methods

### DIFF
--- a/gormigrate.go
+++ b/gormigrate.go
@@ -3,6 +3,7 @@ package gormigrate
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	"gorm.io/gorm"
 )
@@ -330,8 +331,8 @@ func (g *Gormigrate) rollbackMigration(m *Migration) error {
 		return err
 	}
 
-	sql := fmt.Sprintf("DELETE FROM %s WHERE %s = ?", g.options.TableName, g.options.IDColumnName)
-	return g.tx.Exec(sql, m.ID).Error
+	cond := fmt.Sprintf("%s = ?", g.options.IDColumnName)
+	return g.tx.Table(g.options.TableName).Where(cond, m.ID).Delete(g.model()).Error
 }
 
 func (g *Gormigrate) runInitSchema() error {
@@ -372,13 +373,31 @@ func (g *Gormigrate) runMigration(migration *Migration) error {
 	return nil
 }
 
+// model returns pointer to dynamically created gorm migration model struct value
+//
+//	struct defined as {
+//	  ID string `gorm:"primaryKey;column:<Options.IDColumnName>;size:<Options.IDColumnSize>"`
+//	}
+func (g *Gormigrate) model() interface{} {
+	f := reflect.StructField{
+		Name: reflect.ValueOf("ID").Interface().(string),
+		Type: reflect.TypeOf(""),
+		Tag: reflect.StructTag(fmt.Sprintf(
+			`gorm:"primaryKey;column:%s;size:%d"`,
+			g.options.IDColumnName,
+			g.options.IDColumnSize,
+		)),
+	}
+	structType := reflect.StructOf([]reflect.StructField{f})
+	structValue := reflect.New(structType).Elem()
+	return structValue.Addr().Interface()
+}
+
 func (g *Gormigrate) createMigrationTableIfNotExists() error {
 	if g.tx.Migrator().HasTable(g.options.TableName) {
 		return nil
 	}
-
-	sql := fmt.Sprintf("CREATE TABLE %s (%s VARCHAR(%d) PRIMARY KEY)", g.options.TableName, g.options.IDColumnName, g.options.IDColumnSize)
-	return g.tx.Exec(sql).Error
+	return g.tx.Table(g.options.TableName).AutoMigrate(g.model())
 }
 
 func (g *Gormigrate) migrationRan(m *Migration) (bool, error) {
@@ -439,8 +458,8 @@ func (g *Gormigrate) unknownMigrationsHaveHappened() (bool, error) {
 }
 
 func (g *Gormigrate) insertMigration(id string) error {
-	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?)", g.options.TableName, g.options.IDColumnName)
-	return g.tx.Exec(sql, id).Error
+	record := map[string]interface{}{g.options.IDColumnName: id}
+	return g.tx.Table(g.options.TableName).Create(record).Error
 }
 
 func (g *Gormigrate) begin() {


### PR DESCRIPTION
So, getting rid of hard-coded sql mutation statements and switching to native `gorm` methods makes `gormigrate` fully compatible with all supported `gorm` dialects. 
It also optimizes `migrations` table schema per dialect. E.g. it doesn't make sense to define `VARCHAR` types for `sqlite` because it doesn't impose any length restrictions, so `VARCHAR` in fact is `TEXT` in this case.

This is NOT breaking change.