### PR TITLE
Fix go build tags format: "//go:build" is preffered over "// +build" since go 1.17

### DIFF
--- a/mysql_test.go
+++ b/mysql_test.go
@@ -1,4 +1,4 @@
-// +build mysql
+//go:build mysql
 
 package gormigrate_test
 

--- a/postgresql_test.go
+++ b/postgresql_test.go
@@ -1,4 +1,4 @@
-// +build postgresql
+//go:build postgresql
 
 package gormigrate_test
 

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -1,4 +1,4 @@
-// +build sqlite
+//go:build sqlite
 
 package gormigrate_test
 

--- a/sqlserver_test.go
+++ b/sqlserver_test.go
@@ -1,4 +1,4 @@
-// +build sqlserver
+//go:build sqlserver
 
 package gormigrate_test
 


### PR DESCRIPTION
From [Go 1.17 Release Notes](https://go.dev/doc/go1.17):

> //go:build lines
> The go command now understands //go:build lines and prefers them over // +build lines. The new syntax uses boolean expressions, just like Go, and should be less error-prone. As of this release, the new syntax is fully supported, and all Go files should be updated to have both forms with the same meaning. To aid in migration, [gofmt](https://go.dev/doc/go1.17#gofmt) now automatically synchronizes the two forms. For more details on the syntax and migration plan, see [https://golang.org/design/draft-gobuild](https://go.dev/design/draft-gobuild).